### PR TITLE
s6-supervise should also handle SIGINT as SIGTERM

### DIFF
--- a/src/supervision/s6-supervise.c
+++ b/src/supervision/s6-supervise.c
@@ -518,6 +518,7 @@ static inline void handle_signals (void)
           (*actions[state][V_CHLD])() ;
         }
         break ;
+      case SIGINT :
       case SIGTERM :
         (*actions[state][V_TERM])() ;
         break ;
@@ -573,6 +574,7 @@ int main (int argc, char const *const *argv)
     {
       sigset_t set ;
       sigemptyset(&set) ;
+      sigaddset(&set, SIGINT) ;
       sigaddset(&set, SIGTERM) ;
       sigaddset(&set, SIGHUP) ;
       sigaddset(&set, SIGQUIT) ;


### PR DESCRIPTION
as I trying to move from djb daemontools to s6 and playing around,
I found that if I use ctrl+c to stop s6-svscan at console, s6-supervise will also receive SIGINT,

but s6-supervise doesn't handle the signal so it just stopped without clean anything, leave the child process running

I am not sure is this a proper fix for my problem, this is just one way to fix it.